### PR TITLE
Fix offseason years

### DIFF
--- a/src/components/TeamEditorTable.tsx
+++ b/src/components/TeamEditorTable.tsx
@@ -270,9 +270,12 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
 
   /** The year from which we're taking the grades - other averages need to come from that season */
   const gradeYear = (yearIn: string, evalModeIn: boolean, offSeasonModeIn: boolean) => {
-    const firstYearWithGrades = DateUtils.coreYears[0];
     const yearToUse = (evalModeIn || !offSeasonModeIn) ? yearIn : DateUtils.getPrevYear(yearIn);
-    return ((yearIn == "All") || (yearToUse <= firstYearWithGrades)) 
+      //(basically if we're in prediction mode, we use the year before - ie what it would have looked like
+      // before the season started. In "review" mode we obv use the data from that year)
+    const firstYearWithFullD1Grades = DateUtils.yearFromWhichAllMenD1Imported;
+      //(if we have all D1 data use the requested year, otherwise use the last full season)
+    return ((yearIn == "All") || (yearToUse < firstYearWithFullD1Grades)) 
         ? ParamDefaults.defaultLeaderboardYear 
         : yearToUse;
   };
@@ -899,7 +902,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
       </OverlayTrigger> : <b>Team Totals</b>;
 
       const actualResultsYear = 
-        (year == "All") ? "Actual" : (evalMode ? year : DateUtils.getPrevYear(year)).substring(2);
+        (year == "All") ? "Actual" : year.substring(2);
 
       const teamStatsRowData = {
         title: teamLink,

--- a/src/components/TeamEditorTable.tsx
+++ b/src/components/TeamEditorTable.tsx
@@ -269,9 +269,9 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
   // Team Editor specifc logic
 
   /** The year from which we're taking the grades - other averages need to come from that season */
-  const gradeYear = (yearIn: string, evalModeIn: boolean) => {
+  const gradeYear = (yearIn: string, evalModeIn: boolean, offSeasonModeIn: boolean) => {
     const firstYearWithGrades = DateUtils.coreYears[0];
-    const yearToUse = evalModeIn ? yearIn : DateUtils.getPrevYear(yearIn);
+    const yearToUse = (evalModeIn || !offSeasonModeIn) ? yearIn : DateUtils.getPrevYear(yearIn);
     return ((yearIn == "All") || (yearToUse <= firstYearWithGrades)) 
         ? ParamDefaults.defaultLeaderboardYear 
         : yearToUse;
@@ -281,7 +281,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
   useEffect(() => {
     const params = {
       ...startingState, gender,
-      year: usePreseasonRanks ? year : gradeYear(year, evalMode)
+      year: usePreseasonRanks ? year : gradeYear(year, evalMode, offSeasonMode)
     };
 
     if (!_.isEmpty(divisionStatsCache)) setDivisionStatsCache({}); //unset if set
@@ -367,7 +367,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
 
     // Processing - various pxResults are used in the buildXxx functions below
 
-    const genderYearLookupForAvgEff = `${gender}_${gradeYear(year, evalMode)}`; //(use whatever year we're taking grades for)
+    const genderYearLookupForAvgEff = `${gender}_${gradeYear(year, evalMode, offSeasonMode)}`; //(use whatever year we're taking grades for)
     const avgEff = efficiencyAverages[genderYearLookupForAvgEff] || efficiencyAverages.fallback;
 
     const genderPrevSeason = offSeasonMode ? `${gender}_${DateUtils.getPrevYear(yearWithStats)}` : "NO MATCH"; //(for Fr)
@@ -945,7 +945,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
               if (usePreseasonRanks) {
                 return "(preseason)";
               } else {
-                return  ((divisionStatsCache.year != (evalMode ? year : prevYear)) ?
+                return  ((divisionStatsCache.year != ((evalMode || !offSeasonMode) ? year : prevYear)) ?
                 "(generic)"
                 : `(${divisionStatsCache.year.substring(2)})`);
               }

--- a/src/components/TeamEditorTable.tsx
+++ b/src/components/TeamEditorTable.tsx
@@ -1003,7 +1003,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
             </Tooltip>
           );
           const url = UrlRouting.getOffseasonLeaderboard({
-            year: yearWithStats,
+            year: year,
             confs: ConferenceToNickname[confStr],
             teamView: team,
             ...overrides
@@ -1011,14 +1011,14 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
           return <OverlayTrigger placement="auto" overlay={confTooltip}>
             <a href={url}>{confStrToUse}</a>
           </OverlayTrigger>;
-        } else if (year > DateUtils.offseasonYear) {
+        } else if (year == DateUtils.offseasonYear) { //TODO: currently only support review mode 1 year back, add more years
           const confTooltip = (
             <Tooltip id={`confReviewTooltip`}>
                <span>View the evaluation of this team's season (with any overrides) vs its ranking, together with other teams in teh conference</span>
             </Tooltip>
           );
           const url = UrlRouting.getOffseasonLeaderboard({
-            year: year,
+            year: DateUtils.getPrevYear(year), //TODO: currently the team leaderboard interprets year differently in "review" mode, fix this once have fixed that
             confs: ConferenceToNickname[confStr],
             evalMode: true,
             teamView: team,

--- a/src/components/TeamEditorTable.tsx
+++ b/src/components/TeamEditorTable.tsx
@@ -1352,6 +1352,10 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
               const newYear = (option as any).value;
               friendlyChange(() => {
                 setYear(newYear); 
+                if (newYear > DateUtils.offseasonYear) {
+                  setEvalMode(false);
+                  setOffSeasonMode(true);
+                }
                 setOtherPlayerCache({});
                 setDisabledPlayers({});
                 setDeletedPlayers({});
@@ -1416,6 +1420,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
           <GenericTogglingMenuItem
                 text={"'What If?' mode"}
                 truthVal={!offSeasonMode}
+                disabled={year > DateUtils.offseasonYear}
                 onSelect={() => friendlyChange(() => {
                   setOffSeasonModeWithEffects(!offSeasonMode);
                   setEvalMode(false);
@@ -1425,6 +1430,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
           <GenericTogglingMenuItem
               text={"Review mode"}
               truthVal={evalMode}
+              disabled={year > DateUtils.offseasonYear}
               onSelect={() => friendlyChange(() => {
                 setOffSeasonModeWithEffects(true);
                 setEvalMode(!evalMode);
@@ -1445,7 +1451,8 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
               label: "Diff",
               tooltip: "When enabled - saves the team grades from the current roster config, and shows that along with the new grades coming from any subsequent edits",
               toggled: diffBasis != undefined,
-              onClick: () => friendlyChange(() => {
+              disabled: false,
+                onClick: () => friendlyChange(() => {
                 setDiffBasis(_.isNil(diffBasis) ? {} : undefined);
                   //(empty means active and will be filled in when the page rerenders)
               }, true)
@@ -1481,19 +1488,21 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
               label: "What If?",
               tooltip: "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
               toggled: !offSeasonMode,
+              disabled: year > DateUtils.offseasonYear,
               onClick: () => friendlyChange(() => {
                 setOffSeasonModeWithEffects(!offSeasonMode);
                 setEvalMode(false);
-            }, true)
+              }, true)
             },
             {
               label: "Review",
               tooltip: "Compares the off-season projection against what actually happened (/is actually happening) the following year",
               toggled: evalMode,
+              disabled: year > DateUtils.offseasonYear,
               onClick: () => friendlyChange(() => {
-                  setOffSeasonModeWithEffects(true);
-                 setEvalMode(!evalMode);
-                }, true)
+                setOffSeasonModeWithEffects(true);
+                setEvalMode(!evalMode);
+              }, true)
             },
         ]))}
         />

--- a/src/components/TeamEditorTable.tsx
+++ b/src/components/TeamEditorTable.tsx
@@ -1190,7 +1190,7 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
             players: (onlyThisYear && (year != "All"))? 
               (dataEvent.players || []).filter(p => p.year == yearWithStats) : 
               (evalMode ? (dataEvent.players || []).filter(p => (p.year || "") <= yearWithStats) : dataEvent.players), 
-            transfers: (onlyTransfers && hasTransfers) ? dataEvent.transfers?.[0] : undefined 
+            transfers: (onlyTransfers && hasTransfers && (year != "All")) ? dataEvent.transfers?.[0] : undefined 
           }
         )
       }
@@ -1348,14 +1348,19 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
       <Col xs={6} sm={6} md={3} lg={2}>
         <Select
           value={ stringToOption(year) }
-          options={DateUtils.teamEditorYears(offSeasonMode).map(r => stringToOption(r))}
+          options={DateUtils.teamEditorYears(offSeasonMode).concat(
+            offSeasonMode ? [] : [ "All" ]
+          ).map(r => stringToOption(r))}
           isSearchable={false}
           onChange={(option) => { 
             if ((option as any)?.value) {
               const newYear = (option as any).value;
               friendlyChange(() => {
                 setYear(newYear); 
-                if (newYear > DateUtils.offseasonYear) {
+                if (newYear == "All") {
+                  setOffSeasonMode(false);
+                  setEvalMode(false);
+                } else if (newYear > DateUtils.offseasonYear) {
                   setEvalMode(false);
                   setOffSeasonMode(true);
                 }
@@ -1560,9 +1565,9 @@ const TeamEditorTable: React.FunctionComponent<Props> = ({startingState, dataEve
                 />
               </Form.Group>
               <Form.Group as={Col} xs="4" className="mt-2">
-                <Form.Check type="switch" disabled={!hasTransfers || addNewPlayerMode}
+                <Form.Check type="switch" disabled={!hasTransfers || addNewPlayerMode || (year == "All")}
                   id="onlyTransfers"
-                  checked={onlyTransfers && hasTransfers}
+                  checked={onlyTransfers && hasTransfers && (year != "All")}
                   onChange={() => {
                     setTimeout(() => {
                       setReloadData(true);

--- a/src/components/__tests__/OffseasonLeaderboardTable.test.tsx
+++ b/src/components/__tests__/OffseasonLeaderboardTable.test.tsx
@@ -101,7 +101,7 @@ describe("OffseasonLeaderboardTable", () => {
       <OffSeasonLeaderboardTable
          startingState={{
             evalMode: true,
-            year: "2019/20", 
+            year: "2020/21", 
          } as OffseasonLeaderboardParams}
          dataEvent={threeYearsWithEvalTeamStats}
          onChangeState={dummyChangeStateCallback}

--- a/src/components/__tests__/TeamEditorTable.test.tsx
+++ b/src/components/__tests__/TeamEditorTable.test.tsx
@@ -61,7 +61,7 @@ describe("TeamEditorTable", () => {
     const wrapper = shallow(
       <TeamEditorTable
         startingState={{ 
-          team: "Maryland", year: "2019/20", 
+          team: "Maryland", year: "2020/21", 
           offSeason: true, evalMode: false,
           alwaysShowBench: false, superSeniorsBack: false, 
           showOnlyTransfers: true, showOnlyCurrentYear: false
@@ -78,7 +78,7 @@ describe("TeamEditorTable", () => {
     const wrapper = shallow(
       <TeamEditorTable
         startingState={{ 
-          team: "Maryland", year: "2019/20", 
+          team: "Maryland", year: "2020/21", 
           offSeason: true, evalMode: true,
           alwaysShowBench: false, superSeniorsBack: false, 
           showOnlyTransfers: true, showOnlyCurrentYear: false
@@ -94,7 +94,7 @@ describe("TeamEditorTable", () => {
     const wrapper = shallow(
       <TeamEditorTable
         startingState={{ 
-          team: "Maryland", year: "2019/20", 
+          team: "Maryland", year: "2020/21", 
           offSeason: true, evalMode: true,
           alwaysShowBench: false, superSeniorsBack: false, 
           showOnlyTransfers: true, showOnlyCurrentYear: false
@@ -129,7 +129,7 @@ describe("TeamEditorTable", () => {
     const wrapper = shallow(
       <TeamEditorTable
         startingState={{ 
-          team: "Maryland", year: "2019/20", 
+          team: "Maryland", year: "2020/21", 
           offSeason: true, evalMode: false,
           alwaysShowBench: true, superSeniorsBack: true, 
           showOnlyTransfers: false, showOnlyCurrentYear: true
@@ -145,7 +145,7 @@ describe("TeamEditorTable", () => {
     const wrapper = shallow(
       <TeamEditorTable
         startingState={{ 
-          team: "Maryland", year: "2019/20", 
+          team: "Maryland", year: "2020/21", 
           offSeason: true, evalMode: true,
           alwaysShowBench: true, superSeniorsBack: true, 
           showOnlyTransfers: false, showOnlyCurrentYear: true
@@ -194,7 +194,7 @@ describe("TeamEditorTable", () => {
     const wrapper = shallow(
       <TeamEditorTable
         startingState={{ 
-          team: "Maryland", year: "2019/20", 
+          team: "Maryland", year: "2020/21", 
           offSeason: true, evalMode: false,
           alwaysShowBench: false, superSeniorsBack: false, 
           showOnlyTransfers: true, showOnlyCurrentYear: false,
@@ -211,7 +211,7 @@ describe("TeamEditorTable", () => {
     const wrapper = shallow(
       <TeamEditorTable
         startingState={{ 
-          team: "Maryland", year: "2019/20", 
+          team: "Maryland", year: "2020/21", 
           offSeason: true, evalMode: true,
           alwaysShowBench: false, superSeniorsBack: false, 
           showOnlyTransfers: true, showOnlyCurrentYear: false,

--- a/src/components/__tests__/__snapshots__/OffseasonLeaderboardTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/OffseasonLeaderboardTable.test.tsx.snap
@@ -421,7 +421,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - queryFilters + ov
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&overrides=ErAyala%3A%3A%7Cm%3D20.0&team=Maryland&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&overrides=ErAyala%3A%3A%7Cm%3D20.0&team=Maryland&year=2019%2F20&"
                           target="_blank"
                         >
                           Maryland
@@ -1026,7 +1026,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2019%2F20&"
                           target="_blank"
                         >
                           Maryland
@@ -1179,7 +1179,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Illinois&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Illinois&year=2019%2F20&"
                           target="_blank"
                         >
                           Illinois
@@ -1332,7 +1332,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Indiana&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Indiana&year=2019%2F20&"
                           target="_blank"
                         >
                           Indiana
@@ -1485,7 +1485,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa&year=2019%2F20&"
                           target="_blank"
                         >
                           Iowa
@@ -1638,7 +1638,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan&year=2019%2F20&"
                           target="_blank"
                         >
                           Michigan
@@ -1791,7 +1791,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Michigan St.
@@ -1944,7 +1944,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Minnesota&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Minnesota&year=2019%2F20&"
                           target="_blank"
                         >
                           Minnesota
@@ -2097,7 +2097,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Nebraska&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Nebraska&year=2019%2F20&"
                           target="_blank"
                         >
                           Nebraska
@@ -2250,7 +2250,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Northwestern&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Northwestern&year=2019%2F20&"
                           target="_blank"
                         >
                           Northwestern
@@ -2403,7 +2403,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Ohio%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Ohio%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Ohio St.
@@ -2556,7 +2556,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Penn%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Penn%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Penn St.
@@ -2709,7 +2709,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Purdue&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Purdue&year=2019%2F20&"
                           target="_blank"
                         >
                           Purdue
@@ -2862,7 +2862,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Rutgers&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Rutgers&year=2019%2F20&"
                           target="_blank"
                         >
                           Rutgers
@@ -3015,7 +3015,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Wisconsin&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Wisconsin&year=2019%2F20&"
                           target="_blank"
                         >
                           Wisconsin
@@ -3383,7 +3383,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
             "Mountain West Conference",
           ]
         }
-        emptyLabel="All High Tier Teams"
+        emptyLabel="All Teams"
         onChangeConf={[Function]}
       />
     </Col>
@@ -3629,7 +3629,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Maryland&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Maryland&year=2020%2F21&"
                           target="_blank"
                         >
                           Maryland
@@ -3780,7 +3780,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Duke&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Duke&year=2020%2F21&"
                           target="_blank"
                         >
                           Duke
@@ -3931,7 +3931,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Seton%20Hall&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Seton%20Hall&year=2020%2F21&"
                           target="_blank"
                         >
                           Seton Hall
@@ -4082,7 +4082,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Kentucky&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Kentucky&year=2020%2F21&"
                           target="_blank"
                         >
                           Kentucky
@@ -4233,7 +4233,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=North%20Carolina&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=North%20Carolina&year=2020%2F21&"
                           target="_blank"
                         >
                           North Carolina
@@ -4384,7 +4384,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Tennessee&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Tennessee&year=2020%2F21&"
                           target="_blank"
                         >
                           Tennessee
@@ -4535,7 +4535,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Arizona%20St.&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Arizona%20St.&year=2020%2F21&"
                           target="_blank"
                         >
                           Arizona St.
@@ -4686,7 +4686,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Gonzaga&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Gonzaga&year=2020%2F21&"
                           target="_blank"
                         >
                           Gonzaga
@@ -4837,7 +4837,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=LSU&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=LSU&year=2020%2F21&"
                           target="_blank"
                         >
                           LSU
@@ -4988,7 +4988,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Oklahoma%20St.&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Oklahoma%20St.&year=2020%2F21&"
                           target="_blank"
                         >
                           Oklahoma St.
@@ -5139,7 +5139,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Auburn&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Auburn&year=2020%2F21&"
                           target="_blank"
                         >
                           Auburn
@@ -5290,7 +5290,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Stanford&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Stanford&year=2020%2F21&"
                           target="_blank"
                         >
                           Stanford
@@ -5441,7 +5441,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Texas%20Tech&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Texas%20Tech&year=2020%2F21&"
                           target="_blank"
                         >
                           Texas Tech
@@ -5592,7 +5592,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Illinois&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Illinois&year=2020%2F21&"
                           target="_blank"
                         >
                           Illinois
@@ -5743,7 +5743,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Southern%20California&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Southern%20California&year=2020%2F21&"
                           target="_blank"
                         >
                           Southern California
@@ -5894,7 +5894,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Florida%20St.&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Florida%20St.&year=2020%2F21&"
                           target="_blank"
                         >
                           Florida St.
@@ -6045,7 +6045,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Texas&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Texas&year=2020%2F21&"
                           target="_blank"
                         >
                           Texas
@@ -6196,7 +6196,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Kansas&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Kansas&year=2020%2F21&"
                           target="_blank"
                         >
                           Kansas
@@ -6347,7 +6347,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Indiana&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Indiana&year=2020%2F21&"
                           target="_blank"
                         >
                           Indiana
@@ -6498,7 +6498,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Arkansas&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Arkansas&year=2020%2F21&"
                           target="_blank"
                         >
                           Arkansas
@@ -6649,7 +6649,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Virginia&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Virginia&year=2020%2F21&"
                           target="_blank"
                         >
                           Virginia
@@ -6800,7 +6800,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Miami%20%28FL%29&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Miami%20%28FL%29&year=2020%2F21&"
                           target="_blank"
                         >
                           Miami (FL)
@@ -6951,7 +6951,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Arizona&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Arizona&year=2020%2F21&"
                           target="_blank"
                         >
                           Arizona
@@ -7102,7 +7102,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Oregon&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Oregon&year=2020%2F21&"
                           target="_blank"
                         >
                           Oregon
@@ -7253,7 +7253,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Ole%20Miss&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Ole%20Miss&year=2020%2F21&"
                           target="_blank"
                         >
                           Ole Miss
@@ -7404,7 +7404,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Michigan%20St.&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Michigan%20St.&year=2020%2F21&"
                           target="_blank"
                         >
                           Michigan St.
@@ -7574,7 +7574,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Michigan&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Michigan&year=2020%2F21&"
                           target="_blank"
                         >
                           Michigan
@@ -7725,7 +7725,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Xavier&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Xavier&year=2020%2F21&"
                           target="_blank"
                         >
                           Xavier
@@ -7876,7 +7876,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Marquette&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Marquette&year=2020%2F21&"
                           target="_blank"
                         >
                           Marquette
@@ -8027,7 +8027,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Clemson&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Clemson&year=2020%2F21&"
                           target="_blank"
                         >
                           Clemson
@@ -8178,7 +8178,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Florida&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Florida&year=2020%2F21&"
                           target="_blank"
                         >
                           Florida
@@ -8329,7 +8329,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Villanova&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Villanova&year=2020%2F21&"
                           target="_blank"
                         >
                           Villanova
@@ -8480,7 +8480,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Alabama&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Alabama&year=2020%2F21&"
                           target="_blank"
                         >
                           Alabama
@@ -8631,7 +8631,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Rutgers&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Rutgers&year=2020%2F21&"
                           target="_blank"
                         >
                           Rutgers
@@ -8782,7 +8782,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=UCLA&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=UCLA&year=2020%2F21&"
                           target="_blank"
                         >
                           UCLA
@@ -8952,7 +8952,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Texas%20A%26M&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Texas%20A%26M&year=2020%2F21&"
                           target="_blank"
                         >
                           Texas A&M
@@ -9103,7 +9103,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Mississippi%20St.&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Mississippi%20St.&year=2020%2F21&"
                           target="_blank"
                         >
                           Mississippi St.
@@ -9254,7 +9254,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=NC%20State&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=NC%20State&year=2020%2F21&"
                           target="_blank"
                         >
                           NC State
@@ -9405,7 +9405,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Creighton&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Creighton&year=2020%2F21&"
                           target="_blank"
                         >
                           Creighton
@@ -9556,7 +9556,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Wake%20Forest&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Wake%20Forest&year=2020%2F21&"
                           target="_blank"
                         >
                           Wake Forest
@@ -9707,7 +9707,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Purdue&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Purdue&year=2020%2F21&"
                           target="_blank"
                         >
                           Purdue
@@ -9858,7 +9858,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Baylor&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Baylor&year=2020%2F21&"
                           target="_blank"
                         >
                           Baylor
@@ -10009,7 +10009,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Iowa%20St.&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Iowa%20St.&year=2020%2F21&"
                           target="_blank"
                         >
                           Iowa St.
@@ -10160,7 +10160,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=West%20Virginia&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=West%20Virginia&year=2020%2F21&"
                           target="_blank"
                         >
                           West Virginia
@@ -10311,7 +10311,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Syracuse&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Syracuse&year=2020%2F21&"
                           target="_blank"
                         >
                           Syracuse
@@ -10462,7 +10462,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=DePaul&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=DePaul&year=2020%2F21&"
                           target="_blank"
                         >
                           DePaul
@@ -10613,7 +10613,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Georgia&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Georgia&year=2020%2F21&"
                           target="_blank"
                         >
                           Georgia
@@ -10764,7 +10764,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Virginia%20Tech&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Virginia%20Tech&year=2020%2F21&"
                           target="_blank"
                         >
                           Virginia Tech
@@ -10915,7 +10915,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Pittsburgh&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Pittsburgh&year=2020%2F21&"
                           target="_blank"
                         >
                           Pittsburgh
@@ -11066,7 +11066,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Wisconsin&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Wisconsin&year=2020%2F21&"
                           target="_blank"
                         >
                           Wisconsin
@@ -11217,7 +11217,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Georgetown&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Georgetown&year=2020%2F21&"
                           target="_blank"
                         >
                           Georgetown
@@ -11368,7 +11368,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Boston%20College&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Boston%20College&year=2020%2F21&"
                           target="_blank"
                         >
                           Boston College
@@ -11519,7 +11519,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Louisville&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Louisville&year=2020%2F21&"
                           target="_blank"
                         >
                           Louisville
@@ -11670,7 +11670,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Colorado&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Colorado&year=2020%2F21&"
                           target="_blank"
                         >
                           Colorado
@@ -11821,7 +11821,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Utah&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Utah&year=2020%2F21&"
                           target="_blank"
                         >
                           Utah
@@ -11991,7 +11991,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Memphis&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Memphis&year=2020%2F21&"
                           target="_blank"
                         >
                           Memphis
@@ -12014,7 +12014,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     "value": 0.009433962264150941,
                   },
                   "conf": <small>
-                    BE
+                    AAC
                   </small>,
                   "def": Object {
                     "value": 101.8656,
@@ -12142,7 +12142,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=UConn&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=UConn&year=2020%2F21&"
                           target="_blank"
                         >
                           UConn
@@ -12293,7 +12293,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=BYU&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=BYU&year=2020%2F21&"
                           target="_blank"
                         >
                           BYU
@@ -12444,7 +12444,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Butler&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Butler&year=2020%2F21&"
                           target="_blank"
                         >
                           Butler
@@ -12595,7 +12595,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=California&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=California&year=2020%2F21&"
                           target="_blank"
                         >
                           California
@@ -12746,7 +12746,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Cincinnati&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Cincinnati&year=2020%2F21&"
                           target="_blank"
                         >
                           Cincinnati
@@ -12897,7 +12897,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Davidson&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Davidson&year=2020%2F21&"
                           target="_blank"
                         >
                           Davidson
@@ -13048,7 +13048,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Dayton&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Dayton&year=2020%2F21&"
                           target="_blank"
                         >
                           Dayton
@@ -13199,7 +13199,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Duquesne&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Duquesne&year=2020%2F21&"
                           target="_blank"
                         >
                           Duquesne
@@ -13350,7 +13350,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=East%20Carolina&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=East%20Carolina&year=2020%2F21&"
                           target="_blank"
                         >
                           East Carolina
@@ -13501,7 +13501,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Fordham&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Fordham&year=2020%2F21&"
                           target="_blank"
                         >
                           Fordham
@@ -13652,7 +13652,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=George%20Mason&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=George%20Mason&year=2020%2F21&"
                           target="_blank"
                         >
                           George Mason
@@ -13803,7 +13803,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Georgia%20Tech&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Georgia%20Tech&year=2020%2F21&"
                           target="_blank"
                         >
                           Georgia Tech
@@ -13954,7 +13954,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Iowa&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Iowa&year=2020%2F21&"
                           target="_blank"
                         >
                           Iowa
@@ -14105,7 +14105,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Kansas%20St.&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Kansas%20St.&year=2020%2F21&"
                           target="_blank"
                         >
                           Kansas St.
@@ -14256,7 +14256,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=La%20Salle&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=La%20Salle&year=2020%2F21&"
                           target="_blank"
                         >
                           La Salle
@@ -14407,7 +14407,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Massachusetts&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Massachusetts&year=2020%2F21&"
                           target="_blank"
                         >
                           Massachusetts
@@ -14558,7 +14558,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Minnesota&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Minnesota&year=2020%2F21&"
                           target="_blank"
                         >
                           Minnesota
@@ -14709,7 +14709,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Missouri&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Missouri&year=2020%2F21&"
                           target="_blank"
                         >
                           Missouri
@@ -14860,7 +14860,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=true&gender=Men&team=Nebraska&year=2019%2F20&"
+                          href="/TeamEditor?evalMode=true&gender=Men&team=Nebraska&year=2020%2F21&"
                           target="_blank"
                         >
                           Nebraska
@@ -15481,7 +15481,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2019%2F20&"
                           target="_blank"
                         >
                           Maryland
@@ -17346,7 +17346,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                       "evalMode": false,
                       "gender": "Men",
                       "team": "Maryland",
-                      "year": "2018/9",
+                      "year": "2019/20",
                     }
                   }
                 />,
@@ -17485,7 +17485,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Seton%20Hall&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Seton%20Hall&year=2019%2F20&"
                           target="_blank"
                         >
                           Seton Hall
@@ -17632,7 +17632,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Alabama&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Alabama&year=2019%2F20&"
                           target="_blank"
                         >
                           Alabama
@@ -17779,7 +17779,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona&year=2019%2F20&"
                           target="_blank"
                         >
                           Arizona
@@ -17926,7 +17926,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Arizona St.
@@ -18073,7 +18073,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Arkansas&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Arkansas&year=2019%2F20&"
                           target="_blank"
                         >
                           Arkansas
@@ -18220,7 +18220,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Auburn&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Auburn&year=2019%2F20&"
                           target="_blank"
                         >
                           Auburn
@@ -18367,7 +18367,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=BYU&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=BYU&year=2019%2F20&"
                           target="_blank"
                         >
                           BYU
@@ -18514,7 +18514,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Baylor&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Baylor&year=2019%2F20&"
                           target="_blank"
                         >
                           Baylor
@@ -18661,7 +18661,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Boston%20College&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Boston%20College&year=2019%2F20&"
                           target="_blank"
                         >
                           Boston College
@@ -18808,7 +18808,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Butler&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Butler&year=2019%2F20&"
                           target="_blank"
                         >
                           Butler
@@ -18955,7 +18955,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=California&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=California&year=2019%2F20&"
                           target="_blank"
                         >
                           California
@@ -19102,7 +19102,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Cincinnati&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Cincinnati&year=2019%2F20&"
                           target="_blank"
                         >
                           Cincinnati
@@ -19249,7 +19249,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Clemson&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Clemson&year=2019%2F20&"
                           target="_blank"
                         >
                           Clemson
@@ -19396,7 +19396,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Colorado&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Colorado&year=2019%2F20&"
                           target="_blank"
                         >
                           Colorado
@@ -19543,7 +19543,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Creighton&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Creighton&year=2019%2F20&"
                           target="_blank"
                         >
                           Creighton
@@ -19690,7 +19690,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Davidson&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Davidson&year=2019%2F20&"
                           target="_blank"
                         >
                           Davidson
@@ -19837,7 +19837,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Dayton&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Dayton&year=2019%2F20&"
                           target="_blank"
                         >
                           Dayton
@@ -19984,7 +19984,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=DePaul&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=DePaul&year=2019%2F20&"
                           target="_blank"
                         >
                           DePaul
@@ -20131,7 +20131,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Duke&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Duke&year=2019%2F20&"
                           target="_blank"
                         >
                           Duke
@@ -20278,7 +20278,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Duquesne&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Duquesne&year=2019%2F20&"
                           target="_blank"
                         >
                           Duquesne
@@ -20425,7 +20425,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=East%20Carolina&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=East%20Carolina&year=2019%2F20&"
                           target="_blank"
                         >
                           East Carolina
@@ -20572,7 +20572,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida&year=2019%2F20&"
                           target="_blank"
                         >
                           Florida
@@ -20719,7 +20719,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Florida St.
@@ -20866,7 +20866,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Fordham&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Fordham&year=2019%2F20&"
                           target="_blank"
                         >
                           Fordham
@@ -21013,7 +21013,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=George%20Mason&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=George%20Mason&year=2019%2F20&"
                           target="_blank"
                         >
                           George Mason
@@ -21179,7 +21179,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgetown&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgetown&year=2019%2F20&"
                           target="_blank"
                         >
                           Georgetown
@@ -21326,7 +21326,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia&year=2019%2F20&"
                           target="_blank"
                         >
                           Georgia
@@ -21473,7 +21473,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia%20Tech&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia%20Tech&year=2019%2F20&"
                           target="_blank"
                         >
                           Georgia Tech
@@ -21620,7 +21620,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Gonzaga&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Gonzaga&year=2019%2F20&"
                           target="_blank"
                         >
                           Gonzaga
@@ -21767,7 +21767,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Houston&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Houston&year=2019%2F20&"
                           target="_blank"
                         >
                           Houston
@@ -21914,7 +21914,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Illinois&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Illinois&year=2019%2F20&"
                           target="_blank"
                         >
                           Illinois
@@ -22061,7 +22061,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Indiana&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Indiana&year=2019%2F20&"
                           target="_blank"
                         >
                           Indiana
@@ -22208,7 +22208,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa&year=2019%2F20&"
                           target="_blank"
                         >
                           Iowa
@@ -22355,7 +22355,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Iowa St.
@@ -22521,7 +22521,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas&year=2019%2F20&"
                           target="_blank"
                         >
                           Kansas
@@ -22668,7 +22668,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Kansas St.
@@ -22815,7 +22815,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Kentucky&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Kentucky&year=2019%2F20&"
                           target="_blank"
                         >
                           Kentucky
@@ -22962,7 +22962,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=LSU&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=LSU&year=2019%2F20&"
                           target="_blank"
                         >
                           LSU
@@ -23109,7 +23109,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=La%20Salle&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=La%20Salle&year=2019%2F20&"
                           target="_blank"
                         >
                           La Salle
@@ -23256,7 +23256,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Louisville&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Louisville&year=2019%2F20&"
                           target="_blank"
                         >
                           Louisville
@@ -23403,7 +23403,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Marquette&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Marquette&year=2019%2F20&"
                           target="_blank"
                         >
                           Marquette
@@ -23550,7 +23550,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Massachusetts&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Massachusetts&year=2019%2F20&"
                           target="_blank"
                         >
                           Massachusetts
@@ -23697,7 +23697,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Memphis&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Memphis&year=2019%2F20&"
                           target="_blank"
                         >
                           Memphis
@@ -23844,7 +23844,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Miami%20%28FL%29&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Miami%20%28FL%29&year=2019%2F20&"
                           target="_blank"
                         >
                           Miami (FL)
@@ -23991,7 +23991,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan&year=2019%2F20&"
                           target="_blank"
                         >
                           Michigan
@@ -24138,7 +24138,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Michigan St.
@@ -24285,7 +24285,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Minnesota&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Minnesota&year=2019%2F20&"
                           target="_blank"
                         >
                           Minnesota
@@ -24432,7 +24432,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Mississippi%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Mississippi%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Mississippi St.
@@ -24579,7 +24579,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Missouri&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Missouri&year=2019%2F20&"
                           target="_blank"
                         >
                           Missouri
@@ -24726,7 +24726,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=NC%20State&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=NC%20State&year=2019%2F20&"
                           target="_blank"
                         >
                           NC State
@@ -24873,7 +24873,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Nebraska&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Nebraska&year=2019%2F20&"
                           target="_blank"
                         >
                           Nebraska
@@ -25020,7 +25020,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=North%20Carolina&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=North%20Carolina&year=2019%2F20&"
                           target="_blank"
                         >
                           North Carolina
@@ -25167,7 +25167,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Northwestern&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Northwestern&year=2019%2F20&"
                           target="_blank"
                         >
                           Northwestern
@@ -25314,7 +25314,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Notre%20Dame&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Notre%20Dame&year=2019%2F20&"
                           target="_blank"
                         >
                           Notre Dame
@@ -25480,7 +25480,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Ohio%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Ohio%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Ohio St.
@@ -25627,7 +25627,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma&year=2019%2F20&"
                           target="_blank"
                         >
                           Oklahoma
@@ -25774,7 +25774,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Oklahoma St.
@@ -25921,7 +25921,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Ole%20Miss&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Ole%20Miss&year=2019%2F20&"
                           target="_blank"
                         >
                           Ole Miss
@@ -26068,7 +26068,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon&year=2019%2F20&"
                           target="_blank"
                         >
                           Oregon
@@ -26215,7 +26215,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Oregon St.
@@ -26362,7 +26362,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Penn%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Penn%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Penn St.
@@ -26509,7 +26509,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Pittsburgh&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Pittsburgh&year=2019%2F20&"
                           target="_blank"
                         >
                           Pittsburgh
@@ -26656,7 +26656,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Providence&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Providence&year=2019%2F20&"
                           target="_blank"
                         >
                           Providence
@@ -26803,7 +26803,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Purdue&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Purdue&year=2019%2F20&"
                           target="_blank"
                         >
                           Purdue
@@ -26950,7 +26950,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Rhode%20Island&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Rhode%20Island&year=2019%2F20&"
                           target="_blank"
                         >
                           Rhode Island
@@ -27097,7 +27097,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Richmond&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Richmond&year=2019%2F20&"
                           target="_blank"
                         >
                           Richmond
@@ -27244,7 +27244,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Rutgers&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Rutgers&year=2019%2F20&"
                           target="_blank"
                         >
                           Rutgers
@@ -27391,7 +27391,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=SMU&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=SMU&year=2019%2F20&"
                           target="_blank"
                         >
                           SMU
@@ -27538,7 +27538,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Joseph%27s&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Joseph%27s&year=2019%2F20&"
                           target="_blank"
                         >
                           Saint Joseph's
@@ -27685,7 +27685,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Louis&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Louis&year=2019%2F20&"
                           target="_blank"
                         >
                           Saint Louis
@@ -27832,7 +27832,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Mary%27s%20%28CA%29&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Mary%27s%20%28CA%29&year=2019%2F20&"
                           target="_blank"
                         >
                           Saint Mary's (CA)
@@ -27979,7 +27979,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=San%20Diego%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=San%20Diego%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           San Diego St.
@@ -28126,7 +28126,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Carolina&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Carolina&year=2019%2F20&"
                           target="_blank"
                         >
                           South Carolina
@@ -28273,7 +28273,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Fla.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Fla.&year=2019%2F20&"
                           target="_blank"
                         >
                           South Fla.
@@ -28883,7 +28883,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2019%2F20&"
                           target="_blank"
                         >
                           Maryland
@@ -29030,7 +29030,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Seton%20Hall&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Seton%20Hall&year=2019%2F20&"
                           target="_blank"
                         >
                           Seton Hall
@@ -29177,7 +29177,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Alabama&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Alabama&year=2019%2F20&"
                           target="_blank"
                         >
                           Alabama
@@ -29324,7 +29324,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona&year=2019%2F20&"
                           target="_blank"
                         >
                           Arizona
@@ -29471,7 +29471,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Arizona%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Arizona St.
@@ -29618,7 +29618,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Arkansas&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Arkansas&year=2019%2F20&"
                           target="_blank"
                         >
                           Arkansas
@@ -29765,7 +29765,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Auburn&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Auburn&year=2019%2F20&"
                           target="_blank"
                         >
                           Auburn
@@ -29912,7 +29912,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=BYU&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=BYU&year=2019%2F20&"
                           target="_blank"
                         >
                           BYU
@@ -30059,7 +30059,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Baylor&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Baylor&year=2019%2F20&"
                           target="_blank"
                         >
                           Baylor
@@ -30206,7 +30206,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Boston%20College&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Boston%20College&year=2019%2F20&"
                           target="_blank"
                         >
                           Boston College
@@ -30353,7 +30353,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Butler&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Butler&year=2019%2F20&"
                           target="_blank"
                         >
                           Butler
@@ -30500,7 +30500,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=California&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=California&year=2019%2F20&"
                           target="_blank"
                         >
                           California
@@ -30647,7 +30647,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Cincinnati&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Cincinnati&year=2019%2F20&"
                           target="_blank"
                         >
                           Cincinnati
@@ -30794,7 +30794,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Clemson&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Clemson&year=2019%2F20&"
                           target="_blank"
                         >
                           Clemson
@@ -30941,7 +30941,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Colorado&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Colorado&year=2019%2F20&"
                           target="_blank"
                         >
                           Colorado
@@ -31088,7 +31088,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Creighton&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Creighton&year=2019%2F20&"
                           target="_blank"
                         >
                           Creighton
@@ -31235,7 +31235,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Davidson&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Davidson&year=2019%2F20&"
                           target="_blank"
                         >
                           Davidson
@@ -31382,7 +31382,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Dayton&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Dayton&year=2019%2F20&"
                           target="_blank"
                         >
                           Dayton
@@ -31529,7 +31529,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=DePaul&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=DePaul&year=2019%2F20&"
                           target="_blank"
                         >
                           DePaul
@@ -31676,7 +31676,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Duke&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Duke&year=2019%2F20&"
                           target="_blank"
                         >
                           Duke
@@ -31823,7 +31823,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Duquesne&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Duquesne&year=2019%2F20&"
                           target="_blank"
                         >
                           Duquesne
@@ -31970,7 +31970,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=East%20Carolina&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=East%20Carolina&year=2019%2F20&"
                           target="_blank"
                         >
                           East Carolina
@@ -32117,7 +32117,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida&year=2019%2F20&"
                           target="_blank"
                         >
                           Florida
@@ -32264,7 +32264,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Florida%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Florida St.
@@ -32411,7 +32411,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Fordham&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Fordham&year=2019%2F20&"
                           target="_blank"
                         >
                           Fordham
@@ -32558,7 +32558,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=George%20Mason&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=George%20Mason&year=2019%2F20&"
                           target="_blank"
                         >
                           George Mason
@@ -32724,7 +32724,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgetown&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgetown&year=2019%2F20&"
                           target="_blank"
                         >
                           Georgetown
@@ -32871,7 +32871,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia&year=2019%2F20&"
                           target="_blank"
                         >
                           Georgia
@@ -33018,7 +33018,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia%20Tech&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Georgia%20Tech&year=2019%2F20&"
                           target="_blank"
                         >
                           Georgia Tech
@@ -33165,7 +33165,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Gonzaga&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Gonzaga&year=2019%2F20&"
                           target="_blank"
                         >
                           Gonzaga
@@ -33312,7 +33312,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Houston&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Houston&year=2019%2F20&"
                           target="_blank"
                         >
                           Houston
@@ -33459,7 +33459,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Illinois&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Illinois&year=2019%2F20&"
                           target="_blank"
                         >
                           Illinois
@@ -33606,7 +33606,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Indiana&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Indiana&year=2019%2F20&"
                           target="_blank"
                         >
                           Indiana
@@ -33753,7 +33753,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa&year=2019%2F20&"
                           target="_blank"
                         >
                           Iowa
@@ -33900,7 +33900,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Iowa%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Iowa St.
@@ -34066,7 +34066,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas&year=2019%2F20&"
                           target="_blank"
                         >
                           Kansas
@@ -34213,7 +34213,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Kansas%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Kansas St.
@@ -34360,7 +34360,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Kentucky&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Kentucky&year=2019%2F20&"
                           target="_blank"
                         >
                           Kentucky
@@ -34507,7 +34507,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=LSU&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=LSU&year=2019%2F20&"
                           target="_blank"
                         >
                           LSU
@@ -34654,7 +34654,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=La%20Salle&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=La%20Salle&year=2019%2F20&"
                           target="_blank"
                         >
                           La Salle
@@ -34801,7 +34801,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Louisville&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Louisville&year=2019%2F20&"
                           target="_blank"
                         >
                           Louisville
@@ -34948,7 +34948,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Marquette&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Marquette&year=2019%2F20&"
                           target="_blank"
                         >
                           Marquette
@@ -35095,7 +35095,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Massachusetts&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Massachusetts&year=2019%2F20&"
                           target="_blank"
                         >
                           Massachusetts
@@ -35242,7 +35242,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Memphis&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Memphis&year=2019%2F20&"
                           target="_blank"
                         >
                           Memphis
@@ -35389,7 +35389,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Miami%20%28FL%29&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Miami%20%28FL%29&year=2019%2F20&"
                           target="_blank"
                         >
                           Miami (FL)
@@ -35536,7 +35536,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan&year=2019%2F20&"
                           target="_blank"
                         >
                           Michigan
@@ -35683,7 +35683,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Michigan%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Michigan St.
@@ -35830,7 +35830,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Minnesota&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Minnesota&year=2019%2F20&"
                           target="_blank"
                         >
                           Minnesota
@@ -35977,7 +35977,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Mississippi%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Mississippi%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Mississippi St.
@@ -36124,7 +36124,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Missouri&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Missouri&year=2019%2F20&"
                           target="_blank"
                         >
                           Missouri
@@ -36271,7 +36271,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=NC%20State&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=NC%20State&year=2019%2F20&"
                           target="_blank"
                         >
                           NC State
@@ -36418,7 +36418,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Nebraska&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Nebraska&year=2019%2F20&"
                           target="_blank"
                         >
                           Nebraska
@@ -36565,7 +36565,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=North%20Carolina&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=North%20Carolina&year=2019%2F20&"
                           target="_blank"
                         >
                           North Carolina
@@ -36712,7 +36712,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Northwestern&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Northwestern&year=2019%2F20&"
                           target="_blank"
                         >
                           Northwestern
@@ -36859,7 +36859,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Notre%20Dame&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Notre%20Dame&year=2019%2F20&"
                           target="_blank"
                         >
                           Notre Dame
@@ -37025,7 +37025,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Ohio%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Ohio%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Ohio St.
@@ -37172,7 +37172,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma&year=2019%2F20&"
                           target="_blank"
                         >
                           Oklahoma
@@ -37319,7 +37319,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oklahoma%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Oklahoma St.
@@ -37466,7 +37466,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Ole%20Miss&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Ole%20Miss&year=2019%2F20&"
                           target="_blank"
                         >
                           Ole Miss
@@ -37613,7 +37613,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon&year=2019%2F20&"
                           target="_blank"
                         >
                           Oregon
@@ -37760,7 +37760,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Oregon%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Oregon St.
@@ -37907,7 +37907,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Penn%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Penn%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           Penn St.
@@ -38054,7 +38054,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Pittsburgh&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Pittsburgh&year=2019%2F20&"
                           target="_blank"
                         >
                           Pittsburgh
@@ -38201,7 +38201,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Providence&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Providence&year=2019%2F20&"
                           target="_blank"
                         >
                           Providence
@@ -38348,7 +38348,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Purdue&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Purdue&year=2019%2F20&"
                           target="_blank"
                         >
                           Purdue
@@ -38495,7 +38495,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Rhode%20Island&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Rhode%20Island&year=2019%2F20&"
                           target="_blank"
                         >
                           Rhode Island
@@ -38642,7 +38642,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Richmond&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Richmond&year=2019%2F20&"
                           target="_blank"
                         >
                           Richmond
@@ -38789,7 +38789,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Rutgers&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Rutgers&year=2019%2F20&"
                           target="_blank"
                         >
                           Rutgers
@@ -38936,7 +38936,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=SMU&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=SMU&year=2019%2F20&"
                           target="_blank"
                         >
                           SMU
@@ -39083,7 +39083,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Joseph%27s&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Joseph%27s&year=2019%2F20&"
                           target="_blank"
                         >
                           Saint Joseph's
@@ -39230,7 +39230,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Louis&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Louis&year=2019%2F20&"
                           target="_blank"
                         >
                           Saint Louis
@@ -39377,7 +39377,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Mary%27s%20%28CA%29&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Saint%20Mary%27s%20%28CA%29&year=2019%2F20&"
                           target="_blank"
                         >
                           Saint Mary's (CA)
@@ -39524,7 +39524,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=San%20Diego%20St.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=San%20Diego%20St.&year=2019%2F20&"
                           target="_blank"
                         >
                           San Diego St.
@@ -39671,7 +39671,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Carolina&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Carolina&year=2019%2F20&"
                           target="_blank"
                         >
                           South Carolina
@@ -39818,7 +39818,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - should create sna
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Fla.&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=South%20Fla.&year=2019%2F20&"
                           target="_blank"
                         >
                           South Fla.
@@ -40538,7 +40538,7 @@ exports[`OffseasonLeaderboardTable OffseasonLeaderboardTable - transfer in+out +
                     >
                       <b>
                         <a
-                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2018%2F9&"
+                          href="/TeamEditor?evalMode=false&gender=Men&team=Maryland&year=2019%2F20&"
                           target="_blank"
                         >
                           Maryland

--- a/src/components/__tests__/__snapshots__/TeamEditorTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TeamEditorTable.test.tsx.snap
@@ -647,6 +647,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot - with user ed
           truthVal={false}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={false}
@@ -655,6 +656,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot - with user ed
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={false}
@@ -680,6 +682,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot - with user ed
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -710,12 +713,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot - with user ed
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": false,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": false,
@@ -4901,6 +4906,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot 1`] = `
           truthVal={false}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={false}
@@ -4909,6 +4915,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot 1`] = `
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={false}
@@ -4934,6 +4941,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot 1`] = `
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -4964,12 +4972,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot 1`] = `
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": false,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": false,
@@ -8884,6 +8894,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode (le
           truthVal={false}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={false}
@@ -8892,6 +8903,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode (le
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={true}
@@ -8917,6 +8929,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode (le
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -8947,12 +8960,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode (le
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": false,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": true,
@@ -13557,6 +13572,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode - w
           truthVal={false}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={false}
@@ -13565,6 +13581,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode - w
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={true}
@@ -13590,6 +13607,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode - w
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -13620,12 +13638,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode - w
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": false,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": true,
@@ -18589,6 +18609,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode 1`]
           truthVal={false}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={false}
@@ -18597,6 +18618,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode 1`]
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={true}
@@ -18622,6 +18644,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode 1`]
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -18652,12 +18675,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode 1`]
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": false,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": true,
@@ -23457,6 +23482,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode, mi
           truthVal={true}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={false}
@@ -23465,6 +23491,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode, mi
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={true}
@@ -23490,6 +23517,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode, mi
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -23520,12 +23548,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode, mi
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": false,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": true,
@@ -27320,7 +27350,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, eval mode, mi
                   "team": "Maryland",
                   "tier": "All",
                   "transferMode": "2020",
-                  "year": "2019/20",
+                  "year": "2020/21",
                 }
               }
               teamEditorMode={[Function]}
@@ -27980,6 +28010,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, misc display 
           truthVal={true}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={false}
@@ -27988,6 +28019,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, misc display 
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={false}
@@ -28013,6 +28045,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, misc display 
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -28043,12 +28076,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, misc display 
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": false,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": false,
@@ -31038,7 +31073,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, misc display 
                   "team": "Maryland",
                   "tier": "All",
                   "transferMode": "2020",
-                  "year": "2019/20",
+                  "year": "2020/21",
                 }
               }
               teamEditorMode={[Function]}
@@ -31128,6 +31163,10 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
             Object {
               "label": "2021/22",
               "value": "2021/22",
+            },
+            Object {
+              "label": "All",
+              "value": "All",
             },
           ]
         }
@@ -31698,6 +31737,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
           truthVal={false}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={true}
@@ -31706,6 +31746,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={false}
@@ -31731,6 +31772,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -31761,12 +31803,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": true,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": false,
@@ -35344,6 +35388,10 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
               "label": "2021/22",
               "value": "2021/22",
             },
+            Object {
+              "label": "All",
+              "value": "All",
+            },
           ]
         }
         value={
@@ -35913,6 +35961,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
           truthVal={false}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={true}
@@ -35921,6 +35970,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={false}
@@ -35946,6 +35996,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -35976,12 +36027,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode 
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": true,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": false,
@@ -39295,6 +39348,10 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode,
               "label": "2021/22",
               "value": "2021/22",
             },
+            Object {
+              "label": "All",
+              "value": "All",
+            },
           ]
         }
         value={
@@ -39864,6 +39921,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode,
           truthVal={true}
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="'What If?' mode"
           truthVal={true}
@@ -39872,6 +39930,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode,
           role="separator"
         />
         <GenericTogglingMenuItem
+          disabled={false}
           onSelect={[Function]}
           text="Review mode"
           truthVal={false}
@@ -39897,6 +39956,7 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode,
         items={
           Array [
             Object {
+              "disabled": false,
               "label": "Diff",
               "onClick": [Function],
               "toggled": false,
@@ -39927,12 +39987,14 @@ exports[`TeamEditorTable TeamEditorTable - should create snapshot, what if mode,
               "tooltip": "If enabled, assume seniors with eligibility will return (or you can add them from 'Add New Players' (off-season mode only)",
             },
             Object {
+              "disabled": false,
               "label": "What If?",
               "onClick": [Function],
               "toggled": true,
               "tooltip": "Describes what actually happened for the selected season, and allows editing to explore different scenarios",
             },
             Object {
+              "disabled": false,
               "label": "Review",
               "onClick": [Function],
               "toggled": false,

--- a/src/components/shared/TeamRosterEditor.tsx
+++ b/src/components/shared/TeamRosterEditor.tsx
@@ -157,7 +157,7 @@ const TeamRosterEditor: React.FunctionComponent<Props> = ({overrides, onDelete, 
                         pos: currPos,
                         profile: currProfile,
                         global_off_adj: currOffAdj ? currOffAdj : undefined,
-                        global_def_adj: currDefAdj ? currDefAdj : undefined
+                        global_def_adj: currDefAdj ? -currDefAdj : undefined
                      });
                      setCurrName("");
                   }}>Add</Button>

--- a/src/components/shared/ToggleButtonGroup.tsx
+++ b/src/components/shared/ToggleButtonGroup.tsx
@@ -15,7 +15,8 @@ export type ToggleButtonItem = {
   tooltip: string,
   toggled: boolean,
   onClick: () => void,
-  isLabelOnly?: boolean
+  isLabelOnly?: boolean,
+  disabled?: boolean
 }
 
 type Props = {
@@ -35,7 +36,7 @@ const ToggleButtonGroup: React.FunctionComponent<Props> = ({items, override}) =>
             <OverlayTrigger placement="auto" overlay={tooltip(item.tooltip, index)}>
               {(item.isLabelOnly) ?
                 <small>{item.label}</small> :
-                <Button onClick={item.onClick} size="sm" key={"tog" + index} variant={item.toggled ? "dark" : "outline-secondary"}>{item.label}</Button>
+                <Button disabled={item.disabled} onClick={item.onClick} size="sm" key={"tog" + index} variant={item.toggled ? "dark" : "outline-secondary"}>{item.label}</Button>
               }
             </OverlayTrigger>
             &nbsp;&nbsp;

--- a/src/pages/OffseasonLeaderboard.tsx
+++ b/src/pages/OffseasonLeaderboard.tsx
@@ -108,14 +108,18 @@ const OffseasonLeaderboardPage: NextPage<Props> = ({testMode}) => {
 
     const gender = paramObj.gender || ParamDefaults.defaultGender;
     const fullYear =  paramObj.evalMode ?
-      (paramObj.year || DateUtils.getPrevYear(DateUtils.offseasonYear)) : //(first year we can do a review)
-      DateUtils.getPrevYear(paramObj.year || DateUtils.inSeasonYear); //TODO: fix this
+      (paramObj.year || DateUtils.offseasonYear) : //(first year we can do a review)
+      (paramObj.year || DateUtils.offseasonPredictionYear); 
+    const prevYear = DateUtils.getPrevYear(fullYear)
     const tier = (paramObj.tier || "All");
 
-    const transferYear = (DateUtils.getOffseasonOfYear(fullYear) || "").substring(0, 4);
-    const prevYear = DateUtils.getPrevYear(fullYear)
-    const transferYearPrev = (DateUtils.getOffseasonOfYear(prevYear) || "").substring(0, 4);
+    const transferYear = fullYear.substring(0, 4);
+    const transferYearPrev = prevYear.substring(0, 4);
+
+    const yearWithStats = prevYear; 
+    const prevYearWithStats = DateUtils.getPrevYear(yearWithStats); 
     const transferYears = [ transferYear, transferYearPrev ];
+
     if ((fullYear != currYear) || (gender != currGender) || (tier != currTier) || (paramObj.evalMode != currEvalMode)) { // Only need to do this if the data source has changed
       setCurrYear(fullYear);
       setCurrGender(gender)
@@ -123,10 +127,11 @@ const OffseasonLeaderboardPage: NextPage<Props> = ({testMode}) => {
       setCurrEvalMode(paramObj.evalMode || false);
 
       const fetchPlayers = LeaderboardUtils.getMultiYearPlayerLboards(
-        "all", gender, fullYear, tier, transferYears, paramObj.evalMode ? [ DateUtils.getNextYear(fullYear), prevYear ] : [ prevYear ]
+        "all", gender, yearWithStats, tier, transferYears, 
+        paramObj.evalMode ? [ fullYear, prevYearWithStats ] : [ prevYearWithStats ]
       );
       const fetchTeamStats = LeaderboardUtils.getMultiYearTeamStats(
-        gender, fullYear, tier, paramObj.evalMode ? [ DateUtils.getNextYear(fullYear) ] : []
+        gender, yearWithStats, tier, paramObj.evalMode ? [ fullYear ] : []
       );
       const fetchAll = Promise.all([ fetchPlayers, fetchTeamStats ]);
 

--- a/src/pages/TeamEditor.tsx
+++ b/src/pages/TeamEditor.tsx
@@ -141,13 +141,14 @@ const TeamEditorPage: NextPage<Props> = ({testMode}) => {
     const paramObj = teamEditorParams;
 
     const gender = paramObj.gender || ParamDefaults.defaultGender;
-    const fullYear = (paramObj.year || ParamDefaults.defaultLeaderboardYear);
+    const fullYear = (paramObj.year || DateUtils.offseasonPredictionYear);
     const tier = (paramObj.tier || "All");
     const evalMode = (paramObj.evalMode || false);
 
-    const transferYear = (DateUtils.getOffseasonOfYear(fullYear) || "").substring(0, 4);
-    const prevYear = DateUtils.getPrevYear(fullYear)
-    const transferYearPrev = (DateUtils.getOffseasonOfYear(prevYear) || "").substring(0, 4);
+    const transferYear = fullYear.substring(0, 4); 
+    const prevYear = DateUtils.getPrevYear(fullYear); 
+    const twoYearsAgo = DateUtils.getPrevYear(prevYear); 
+    const transferYearPrev = prevYear.substring(0, 4);
     const transferYears = [ transferYear, transferYearPrev ];
 
     if ((fullYear != currYear) || (gender != currGender) || (tier != currTier) || (evalMode != currEvalMode)) { // Only need to do this if the data source has changed
@@ -157,11 +158,11 @@ const TeamEditorPage: NextPage<Props> = ({testMode}) => {
       setCurrEvalMode(evalMode);
 
       const fetchPlayers = LeaderboardUtils.getMultiYearPlayerLboards(
-        "all", gender, fullYear, tier, transferYears, 
-        paramObj.evalMode ? [ DateUtils.getNextYear(fullYear), prevYear ] : [ prevYear ]
+        "all", gender, prevYear, tier, transferYears, 
+        paramObj.evalMode ? [ fullYear, twoYearsAgo ] : [ twoYearsAgo ]
       );
       const fetchTeamStats = LeaderboardUtils.getMultiYearTeamStats(
-        gender, fullYear, tier, paramObj.evalMode ? [ DateUtils.getNextYear(fullYear) ] : []
+        gender, prevYear, tier, paramObj.evalMode ? [ fullYear ] : []
       );
       const fetchAll = Promise.all([ fetchPlayers, fetchTeamStats ]);
 

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -39,6 +39,9 @@ export class DateUtils {
    /** Used for defaults for everything but leaderboards (which get updated later) */
    static readonly mostRecentYearWithData = "2021/22";
 
+   /** The year to use if making off-season predictions */
+   static readonly offseasonPredictionYear = "2022/23";
+
    /** Used for leaderboard defaults, which lags behind (player + lineups, currently teams but that might change later) */
    static readonly mostRecentYearWithLboardData = "2021/22";
 
@@ -105,7 +108,9 @@ export class DateUtils {
    };
    /** Get the next season */
    static readonly getNextYear = (y: string) => {
-      if (y == "2021/22") { 
+      if (y == "2022/23") { 
+         return "2023/24";
+      } else if (y == "2021/22") { 
          return "2022/23";
       } else if (y == "2020/21") { //TODO: From 2020/21 onwards can calculate
          return "2021/22";
@@ -120,9 +125,8 @@ export class DateUtils {
       }
    };
    /** Next season if we have data for it else  */
-   static readonly getNextSeasonOrLastWithData = (y: string) => {
-      const nextYear = DateUtils.getNextYear(y);
-      return ((nextYear == "None") || (nextYear > DateUtils.mostRecentYearWithData)) ? DateUtils.mostRecentYearWithData : nextYear;
+   static readonly getLastSeasonWithDataFrom = (y: string) => {
+      return ((y > DateUtils.mostRecentYearWithData)) ? DateUtils.mostRecentYearWithData : y;
    };
          
    /** Get the offseason of the current season */


### PR DESCRIPTION
For expediency reasons I started off with my off season content using the year before. This is very confusing and resulted in hacky translations between the URL and UI. I couldn't immediately fix it because the links were in active use. Now that we're in a quiet spell I'll fix (potentially invalidating some old links, oh well)

Things left to do:
* [x] Fix links on team editor page
* [x] Fix team leaderboard page
* [x] Fix/ensure add players
* Not directly related but might as well fix with some manual re-testing inevitable
   * [x] (~might fix adding players with year set to `All`~ this works fine in "what if" mode, which is the only way it should be used)
   * [x] (~filter out NBA transfers from previous years~ <- this is fine, there is a buglet/unintended feature that if you click show only transfers off, it shows where they transferred anyway, which is kinda cool)
   * [x] (when you add a player with adjustments via player builder, the def is applied in the wrong direction)